### PR TITLE
Update Sentry.NET to 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Update Sentry.NET SDK to 3.3.0 @lucas-zimerman
+* Update Sentry.NET SDK to 3.3.0 (#63) @lucas-zimerman
 
 ## 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unchanged
+
+### Changes
+
+* Update Sentry.NET SDK to 3.3.0 @lucas-zimerman
+
 ## 1.0.3
 
 ### Changes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Sentry" Version="3.0.8" />
+	  <PackageReference Include="Sentry" Version="3.3.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />


### PR DESCRIPTION
 With that, Sentry.Xamarin will get additional features like when the app was started and the device boot time.