### PR TITLE
Fix: Device brand set on device manufacture  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* Changed the data from Device.Manufacturer Device.Brand. @lucas-zimerman
 * Update Sentry.NET SDK to 3.3.0 (#63) @lucas-zimerman
 
 ## 1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Changed the data from Device.Manufacturer Device.Brand. @lucas-zimerman
+* Changed the data from Device.Manufacturer Device.Brand (#70) @lucas-zimerman
 * Update Sentry.NET SDK to 3.3.0 (#63) @lucas-zimerman
 
 ## 1.0.3

--- a/Src/Sentry.Xamarin/Internals/XamarinEventProcessor.cs
+++ b/Src/Sentry.Xamarin/Internals/XamarinEventProcessor.cs
@@ -22,7 +22,7 @@ namespace Sentry.Xamarin.Internals
 
         private class FormsContext
         {
-            internal string Manufacturer { get; }
+            internal string Brand { get; }
             internal string Model { get; }
             internal string Platform { get; }
             internal string PlatformVersion { get; }
@@ -33,7 +33,7 @@ namespace Sentry.Xamarin.Internals
 
             internal FormsContext()
             {
-                Manufacturer = DeviceInfo.Manufacturer.FilterUnknownOrEmpty();
+                Brand = DeviceInfo.Manufacturer.FilterUnknownOrEmpty();
                 Model = DeviceInfo.Model.FilterUnknownOrEmpty();
                 Platform = DeviceInfo.Platform.ToString();
                 PlatformVersion = DeviceInfo.VersionString;
@@ -78,7 +78,7 @@ namespace Sentry.Xamarin.Internals
                     }
 
                     @event.Contexts.Device.Simulator = formsContext.IsEmulator;
-                    @event.Contexts.Device.Manufacturer = formsContext.Manufacturer;
+                    @event.Contexts.Device.Brand = formsContext.Brand;
                     @event.Contexts.Device.Model = formsContext.Model;
                     @event.Contexts.OperatingSystem.Name = formsContext.Platform;
                     @event.Contexts.OperatingSystem.Version = formsContext.PlatformVersion;


### PR DESCRIPTION
I noticed weird data during dogfooding and it seems like the Xamarin Essentials Manufacture data is the expected data for the field device brand.

the proposed fix is just to set the DeviceInfo.Manufacturer parameter as a device.Brand.

![image](https://user-images.githubusercontent.com/8229322/119272850-809f7600-bbde-11eb-8614-3c5bea230cec.png)
event 4811c4c8 got the fixed applied while ...841 is the current state of this SDK.

![image](https://user-images.githubusercontent.com/8229322/119272899-b6dcf580-bbde-11eb-9e4c-811b2d72eca3.png)
a sample picture of an event revealing the brand being set to the wrong parameter.