### PR TITLE
fix IsEnvironmentUser disabled by default and Json issue on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* IsEnvironmentUser is not set to false by default
 * Changed the data from Device.Manufacturer Device.Brand (#70) @lucas-zimerman
 * Update Sentry.NET SDK to 3.3.0 (#63) @lucas-zimerman
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* IsEnvironmentUser is not set to false by default
+* IsEnvironmentUser is not set to false by default (#73) @lucas-zimerman
 * Changed the data from Device.Manufacturer Device.Brand (#70) @lucas-zimerman
 * Update Sentry.NET SDK to 3.3.0 (#63) @lucas-zimerman
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Sentry" Version="3.3.0" />
+    <PackageReference Include="Sentry" Version="3.5.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -47,6 +47,8 @@
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarinios')) ">
 		<Compile Include="Internals\*.ios.cs" />
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+		<PackageReference Include="System.Buffers" Version="4.5.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid')) ">

--- a/Src/Sentry.Xamarin/SentryXamarinOptions.cs
+++ b/Src/Sentry.Xamarin/SentryXamarinOptions.cs
@@ -16,6 +16,9 @@ namespace Sentry
         internal int GetCurrentApplicationDelay { get; set; } = 500;
         internal int GetCurrentApplicationMaxRetries { get; set; } = 15;
 
+        /// <summary>
+        /// The Sentry Xamarin Options.
+        /// </summary>
         public SentryXamarinOptions()
         {
             IsEnvironmentUser = false;

--- a/Src/Sentry.Xamarin/SentryXamarinOptions.cs
+++ b/Src/Sentry.Xamarin/SentryXamarinOptions.cs
@@ -15,5 +15,10 @@ namespace Sentry
         internal string ProjectName { get; set; }
         internal int GetCurrentApplicationDelay { get; set; } = 500;
         internal int GetCurrentApplicationMaxRetries { get; set; } = 15;
+
+        public SentryXamarinOptions()
+        {
+            IsEnvironmentUser = false;
+        }
     }
 }


### PR DESCRIPTION
The following PR includes.
* Sentry SDK version increased to 3.5.0
* IsEnvironmentUserDisabled by  default 
* Fix https://github.com/getsentry/sentry-dotnet/issues/931 and https://github.com/getsentry/sentry-xamarin/issues/72 by adding the correct NuGet package references.