### PR TITLE
Fix break change with new MacOS image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-dotnet@v1.7.2
         with:
               dotnet-version: '5.0.100'
+      - uses: nuget/setup-nuget@v1
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release /t:restore
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-dotnet@v1.7.2
         with:
               dotnet-version: '5.0.100'
-      - uses: microsoft/setup-msbuild@v1.0.2
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release /t:restore
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: '5.0.100'
-      - uses: nuget/setup-nuget@v1
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,9 @@ jobs:
         with:
               dotnet-version: '5.0.100'
       - uses: nuget/setup-nuget@v1
-      - run: dotnet msbuild Sentry.Xamarin.sln /restore
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
+      - run: msbuild Sentry.Xamarin.sln /restore
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
       - name: Build iOS Sample app

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-dotnet@v1.7.2
         with:
               dotnet-version: '5.0.100'
-      - uses: nuget/setup-nuget@v1
-      - run: nuget restore Sentry.Xamarin.sln
+      - uses: microsoft/setup-msbuild@v1.0.2
+      - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release /t:restore
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
       - name: Build Solution with MSBuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
               dotnet-version: '5.0.100'
       - uses: nuget/setup-nuget@v1
       - uses: microsoft/setup-msbuild@v1.1
-        if: matrix.os == 'windows-latest'
+        #if: matrix.os == 'windows-latest'
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1.7.2
+      - uses: actions/setup-dotnet@v1
         with:
-              dotnet-version: '5.0.100'
+          dotnet-version: '6.0.x'
       - uses: nuget/setup-nuget@v1
       - uses: microsoft/setup-msbuild@v1.1
-        #if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest'
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '5.0.100'
       - uses: nuget/setup-nuget@v1
-      - uses: microsoft/setup-msbuild@v1.1
+      - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
       - name: Build Solution with MSBuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,10 +30,10 @@ jobs:
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
       - name: Build iOS Sample app
-        run: msbuild Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
+        run: msbuild Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj -p:Configuration=Release
         if: matrix.os == 'macos-latest'
       - name: Build Android Sample app
-        run: msbuild Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+        run: msbuild Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj -p:Configuration=Release
         if: matrix.os == 'windows-latest'
       - name: Build UWP Sample app
         run: msbuild Samples/Sample.Xamarin.UWP/Sample.Xamarin.UWP.csproj /p:Platform=x64 /p:Configuration=Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,9 @@ jobs:
         with:
               dotnet-version: '5.0.100'
       - uses: nuget/setup-nuget@v1
-      - uses: microsoft/setup-msbuild@v1.0.2
+      - uses: microsoft/setup-msbuild@v1.1
         if: matrix.os == 'windows-latest'
-      - run: msbuild Sentry.Xamarin.sln /restore
+      - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
       - name: Build iOS Sample app

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
               dotnet-version: '5.0.100'
       - uses: nuget/setup-nuget@v1
-      - run: dotnet msbuild Sentry.Xamarin.sln -p:Configuration=Release /t:restore
+      - run: dotnet msbuild Sentry.Xamarin.sln /restore
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
       - name: Build Solution with MSBuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
               dotnet-version: '5.0.100'
       - uses: nuget/setup-nuget@v1
-      - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release /t:restore
+      - run: dotnet msbuild Sentry.Xamarin.sln -p:Configuration=Release /t:restore
       - uses: microsoft/setup-msbuild@v1.0.2
         if: matrix.os == 'windows-latest'
       - name: Build Solution with MSBuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,9 @@ jobs:
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
+      - name: Restore iOS Sample app NuGet
+        run: msbuild Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj -p:Configuration=Release -t:restore
+        if: matrix.os == 'macos-latest'
       - name: Build iOS Sample app
         run: msbuild Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj -p:Configuration=Release
         if: matrix.os == 'macos-latest'

--- a/Samples/Sample.Xamarin.Core/Sample.Xamarin.Core.csproj
+++ b/Samples/Sample.Xamarin.Core/Sample.Xamarin.Core.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.14" />
+    <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.13" />
     <PackageReference Include="Xamanimation" Version="1.3.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2291" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />

--- a/Samples/Sample.Xamarin.Core/Sample.Xamarin.Core.csproj
+++ b/Samples/Sample.Xamarin.Core/Sample.Xamarin.Core.csproj
@@ -12,10 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.9" />
+    <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.14" />
     <PackageReference Include="Xamanimation" Version="1.3.0" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2291" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+++ b/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
@@ -61,13 +61,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.9</Version>
+      <Version>2.0.0.14</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2291" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Dependencies\NativeCrash.cs" />

--- a/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+++ b/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.14</Version>
+      <Version>2.0.0.13</Version>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.4</Version>

--- a/Samples/Sample.Xamarin.UWP/Sample.Xamarin.UWP.csproj
+++ b/Samples/Sample.Xamarin.UWP/Sample.Xamarin.UWP.csproj
@@ -156,7 +156,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.14</Version>
+      <Version>2.0.0.13</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.7.0</Version>

--- a/Samples/Sample.Xamarin.UWP/Sample.Xamarin.UWP.csproj
+++ b/Samples/Sample.Xamarin.UWP/Sample.Xamarin.UWP.csproj
@@ -156,13 +156,13 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.9</Version>
+      <Version>2.0.0.14</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Essentials">
-      <Version>1.6.1</Version>
+      <Version>1.7.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>4.8.0.1451</Version>
+      <Version>5.0.0.2291</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Sample.Xamarin.iOS/Dependencies/NativeCrash.cs
+++ b/Samples/Sample.Xamarin.iOS/Dependencies/NativeCrash.cs
@@ -1,6 +1,4 @@
-﻿
-
-using Foundation;
+﻿using Foundation;
 using Sample.Xamarin.Core.Interfaces;
 using Sample.Xamarin.iOS.Dependencies;
 using Xamarin.Forms;

--- a/Samples/Sample.Xamarin.iOS/Main.cs
+++ b/Samples/Sample.Xamarin.iOS/Main.cs
@@ -6,7 +6,7 @@ namespace Sample.Xamarin.iOS
     {
         static void Main(string[] args)
         {
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, null, typeof(AppDelegate));
         }
     }
 }

--- a/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
+++ b/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
@@ -129,7 +129,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.14</Version>
+      <Version>2.0.0.13</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2291" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />

--- a/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
+++ b/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
@@ -129,10 +129,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup">
-      <Version>2.0.0.9</Version>
+      <Version>2.0.0.14</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2291" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
     <!-- Required to work around an issue with Mono and transient dependencies that require this type -->
     <PackageReference Include="System.Memory" Version="4.5.4" IncludeAssets="None" />
   </ItemGroup>


### PR DESCRIPTION
NuGet Restore now throws an error on macOS when trying to restore a UWP project, the previous behavior was UWP projects were ignored on macOS.
MSBuild will do the same operation but ignore the UWP platform on  macOS.

#skip-changelog.