### PR TITLE
Refactor page navigation

### DIFF
--- a/Samples/Sample.Xamarin.Droid/MainActivity.cs
+++ b/Samples/Sample.Xamarin.Droid/MainActivity.cs
@@ -17,7 +17,7 @@ namespace Sample.Xamarin.Droid
         {
             SentryXamarin.Init(options =>
             {
-                options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
+                options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@sentry.io/5560112";
                 options.AddXamarinFormsIntegration();
                 options.Debug = true;
                 options.AttachScreenshots = true;

--- a/Src/Sentry.Xamarin.Forms/Extensibility/DisabledNavigationPage.cs
+++ b/Src/Sentry.Xamarin.Forms/Extensibility/DisabledNavigationPage.cs
@@ -1,0 +1,15 @@
+﻿using Sentry.Xamarin.Internals;
+
+namespace Sentry.Xamarin.Forms.Extensibility
+{
+    internal class DisabledNavigationPage : IPageNavigationTracker
+    {
+        public static DisabledNavigationPage Instance = new();
+
+        public string CurrentPage => null;
+
+        public void Register(IHub hub, SentryOptions options) { }
+
+        public void Unregister() { }
+    }
+}

--- a/Src/Sentry.Xamarin.Forms/Extensions/SentryXamarinOptionsExtensions.cs
+++ b/Src/Sentry.Xamarin.Forms/Extensions/SentryXamarinOptionsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Sentry.Xamarin.Forms.Internals;
+﻿using Sentry.Xamarin.Forms.Extensibility;
+using Sentry.Xamarin.Forms.Internals;
 
 namespace Sentry
 {
@@ -15,8 +16,33 @@ namespace Sentry
         /// <param name="options">The Sentry Xamarion Options.</param>
         public static void AddXamarinFormsIntegration(this SentryXamarinOptions options)
         {
-            options.AddPageNavigationTrackerIntegration(new SentryXamarinFormsIntegration());
+            var applicationListener = new FormsApplicationListener(options);
+
+            var formsIntegration = new SentryXamarinFormsIntegration(options);
+            options.AddIntegration(formsIntegration);
+            applicationListener.AddListener(formsIntegration.RegisterRequestThemeChange);
+
+            if (options.PageTracker is null)
+            {
+                var navigationIntegration = new FormsNavigationIntegration();
+                options.AddPageNavigationTrackerIntegration(navigationIntegration);
+                applicationListener.AddListener(navigationIntegration.ApplySentryNavigationEvents);
+            }
+
             options.ProtocolPackageName = ProtocolPackageName;
+
+            applicationListener.Invoke();
+        }
+
+        /// <summary>
+        /// Disables the default integration that registers the page and popup navigation.
+        /// </summary>
+        /// <param name="options">The Sentry Xamarion Options.</param>
+        public static void RemoveNavigationPageIntegration(this SentryXamarinOptions options)
+        {
+            options.PageTracker?.Unregister();
+            options.PageTracker = DisabledNavigationPage.Instance;
+
         }
     }
 }

--- a/Src/Sentry.Xamarin.Forms/Internals/FormsApplicationListener.cs
+++ b/Src/Sentry.Xamarin.Forms/Internals/FormsApplicationListener.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+
+namespace Sentry.Xamarin.Forms.Internals
+{
+    internal class FormsApplicationListener
+    {
+        private List<Action<Application>> _listeners { get; } = new List<Action<Application>>();
+
+        private SentryXamarinOptions _options { get; }
+
+        /// <summary>
+        /// Class that returns the current application to any listener once available.
+        /// </summary>
+        /// <param name="options"> The sentry Xamarin options.</param>
+        public FormsApplicationListener(SentryXamarinOptions options) => _options = options;
+
+        /// <summary>
+        ///  Adds a callback to a function that requires the Application.
+        /// </summary>
+        /// <param name="listener"> A function that requires the application in order to work properly.</param>
+        public void AddListener(Action<Application> listener) => _listeners.Add(listener);
+
+        /// <summary>
+        /// Inokes a task that will wait for the initialization of Application.Current.
+        /// On Success, it'll return the current application to all registered listeners. 
+        /// </summary>
+        public void Invoke() =>
+            //Don't lock the main Thread while waiting for the current application to be created.
+            Task.Run(async () =>
+            {
+                var application = await GetCurrentApplication().ConfigureAwait(false);
+                if (application is null)
+                {
+                    _options.DiagnosticLogger?.Log(SentryLevel.Warning, "Sentry.Xamarin.Forms timeout for tracking Application.Current. Navigation tracking is going to be disabled");
+                    return;
+                }
+
+                foreach(var hook in _listeners)
+                {
+                    hook.Invoke(application);
+                }
+                _listeners.Clear();
+            });
+
+
+        /// <summary>
+        /// Get the current Application.
+        /// If SentrySDK was initialized from the Native project (Android/IOS) the Application might not have been created in time.
+        /// So we wait for max 7 seconds to see check if it was created or not
+        /// </summary>
+        /// <returns>Current application.</returns>
+        private async Task<Application> GetCurrentApplication()
+        {
+            for (int i = 0; i < _options.GetCurrentApplicationMaxRetries && Application.Current is null; i++)
+            {
+                await Task.Delay(_options.GetCurrentApplicationDelay).ConfigureAwait(false);
+            }
+            return Application.Current;
+        }
+
+    }
+}

--- a/Src/Sentry.Xamarin.Forms/Internals/FormsNavigationIntegration.cs
+++ b/Src/Sentry.Xamarin.Forms/Internals/FormsNavigationIntegration.cs
@@ -1,0 +1,94 @@
+﻿using Sentry.Xamarin.Forms.Extensions;
+using Sentry.Xamarin.Internals;
+using System.Collections.Generic;
+using Xamarin.Forms;
+
+namespace Sentry.Xamarin.Forms.Internals
+{
+    internal class FormsNavigationIntegration : IPageNavigationTracker
+    {
+        public string CurrentPage { get; private set; }
+        private IHub _hub { get; set; }
+
+        private bool _disabled { get; set; }
+
+        /// <summary>
+        /// Registers the Page appearing and disappearing event to the given application..
+        /// </summary>
+        /// <param name="application">The Xamarin Application.</param>
+        internal void ApplySentryNavigationEvents(Application application)
+        {
+            if (!_disabled)
+            {
+                application.PageAppearing += Current_PageAppearing;
+                application.PageDisappearing += Current_PageDisappearing;
+            }
+        }
+
+        public void Register(IHub hub, SentryOptions _) => _hub = hub;
+
+        /// <summary>
+        /// Removes the PageDissapearing and PageAppearing events from the main Application, if found.
+        /// </summary>
+        public void Unregister()
+        {
+            if (!_disabled)
+            {
+                _disabled = true;
+                if (Application.Current is not null)
+                {
+                    Application.Current.PageAppearing -= Current_PageAppearing;
+                    Application.Current.PageDisappearing -= Current_PageDisappearing;
+                }
+            }
+        }
+
+        private void Current_PageDisappearing(object sender, Page e)
+        {
+            var type = e.GetPageType();
+            if (type.BaseType.StartsWith("PopupPage"))
+            {
+                _hub?.AddBreadcrumb(null,
+                    "ui.lifecycle",
+                    "navigation",
+                    new Dictionary<string, string>
+                    {
+                        ["popup"] = type.Name,
+                        ["state"] = "disappearing"
+                    }, level: BreadcrumbLevel.Info);
+            }
+        }
+
+        private void Current_PageAppearing(object sender, Page e)
+        {
+            var pageType = e.GetPageType();
+            if (CurrentPage != null && CurrentPage != pageType.Name)
+            {
+                if (pageType.Name is "NavigationPage")
+                {
+                    return;
+                }
+                if (pageType.BaseType is "PopupPage")
+                {
+                    _hub?.AddBreadcrumb(null,
+                        "ui.lifecycle",
+                        "navigation",
+                        new Dictionary<string, string>
+                        {
+                            ["popup"] = pageType.Name,
+                            ["state"] = "appearing"
+                        }, level: BreadcrumbLevel.Info);
+                    return;
+                }
+                else
+                {
+                    _hub?.AddBreadcrumb(null,
+                        "navigation",
+                        "navigation",
+                        new Dictionary<string, string> { { "from", $"/{CurrentPage}" }, { "to", $"/{pageType.Name}" } });
+                }
+            }
+            CurrentPage = pageType.Name;
+        }
+    }
+}

--- a/Src/Sentry.Xamarin.Forms/Internals/SentryXamarinFormsIntegration.cs
+++ b/Src/Sentry.Xamarin.Forms/Internals/SentryXamarinFormsIntegration.cs
@@ -1,25 +1,19 @@
 ﻿using Sentry.Extensions;
-using Sentry.Xamarin.Forms.Extensions;
-using Sentry.Xamarin.Internals;
+using Sentry.Integrations;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
 
 namespace Sentry.Xamarin.Forms.Internals
 {
-    internal class SentryXamarinFormsIntegration : IPageNavigationTracker
+    internal class SentryXamarinFormsIntegration : ISdkIntegration
     {
-        internal static SentryXamarinFormsIntegration Instance;
-        private SentryXamarinOptions _options;
-        private DelegateLogListener _xamarinLogger;
-        private IHub _hub;
+        internal static SentryXamarinFormsIntegration Instance { get; set; }
+        private SentryXamarinOptions _options { get; }
+        private DelegateLogListener _xamarinLogger { get; set; }
+        private IHub _hub { get; set; }
 
-        public string CurrentPage { get; private set; }
-        public void RegisterXamarinOptions(SentryXamarinOptions options)
-        {
-            _options = options;
-        }
+        public SentryXamarinFormsIntegration(SentryXamarinOptions options) => _options = options;
 
         /// <summary>
         /// Register the Sentry Xamarin Forms SDK on Sentry.NET SDK
@@ -37,38 +31,29 @@ namespace Sentry.Xamarin.Forms.Internals
             _hub = hub;
 
             RegisterXamarinFormsLogListener(hub);
-
-            //Don't lock the main Thread while waiting for the current application to be created.
-            Task.Run(async () =>
-            {
-                var application = await GetCurrentApplication().ConfigureAwait(false);
-                if (application is null)
-                {
-                    options.DiagnosticLogger?.Log(SentryLevel.Warning, "Sentry.Xamarin.Forms timeout for tracking Application.Current. Navigation tracking is going to be disabled");
-                }
-                else
-                {
-                    application.PageAppearing += Current_PageAppearing;
-                    application.PageDisappearing += Current_PageDisappearing;
-                    application.RequestedThemeChanged += Current_RequestedThemeChanged;
-                }
-            });
         }
+
+        /// <summary>
+        /// creates breadcrumbs from events received from RequestedThemeChanged on the given application.
+        /// </summary>
+        /// <param name="application">The Xamarin Application.</param>
+        internal void RegisterRequestThemeChange(Application application)
+            => application.RequestedThemeChanged += Current_RequestedThemeChanged;
 
         internal void RegisterXamarinFormsLogListener(IHub hub)
         {
-            _xamarinLogger = new DelegateLogListener((arg1, arg2) =>
+            _xamarinLogger = new DelegateLogListener((logger, issue) =>
             {
                 if (_options.XamarinLoggerEnabled)
                 {
-                    hub.AddInternalBreadcrumb(_options,
+                    hub?.AddInternalBreadcrumb(_options,
                         null,
                         "xamarin",
                         "info",
                         new Dictionary<string, string>
                         {
-                            ["logger"] = arg1,
-                            ["issue"] = arg2
+                            ["logger"] = logger,
+                            ["issue"] = issue
                         }, level: BreadcrumbLevel.Warning);
                 }
             });
@@ -79,72 +64,7 @@ namespace Sentry.Xamarin.Forms.Internals
             }
         }
 
-        /// <summary>
-        /// Gets the current Application.
-        /// If SentrySDK was initialized from the Native project (Android/IOS) the Application might not have been created in time.
-        /// So we wait for max 7 seconds to see check if it was created or not
-        /// </summary>
-        /// <returns>Current application.</returns>
-        private async Task<Application> GetCurrentApplication()
-        {
-            for (int i = 0; i < _options.GetCurrentApplicationMaxRetries && Application.Current is null; i++)
-            {
-                await Task.Delay(_options.GetCurrentApplicationDelay).ConfigureAwait(false);
-            }
-            return Application.Current;
-        }
-
-        private void Current_RequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
-        {
-            _hub.AddBreadcrumb(e.RequestedTheme.ToString(), "AppTheme.Change", level: BreadcrumbLevel.Info);
-        }
-
-        private void Current_PageDisappearing(object sender, Page e)
-        {
-            var type = e.GetPageType();
-            if (type.BaseType.StartsWith("PopupPage"))
-            {
-                _hub.AddBreadcrumb(null,
-                    "ui.lifecycle",
-                    "navigation",
-                    new Dictionary<string, string>
-                    {
-                        ["popup"] = type.Name,
-                        ["state"] = "disappearing"
-                    }, level: BreadcrumbLevel.Info);
-            }
-        }
-
-        private void Current_PageAppearing(object sender, Page e)
-        {
-            var pageType = e.GetPageType();
-            if (CurrentPage != null && CurrentPage != pageType.Name)
-            {
-                if (pageType.Name is "NavigationPage")
-                {
-                    return;
-                }
-                if (pageType.BaseType is "PopupPage")
-                {
-                    _hub.AddBreadcrumb(null,
-                        "ui.lifecycle",
-                        "navigation",
-                        new Dictionary<string, string>
-                        {
-                            ["popup"] = pageType.Name,
-                            ["state"] = "appearing"
-                        }, level: BreadcrumbLevel.Info);
-                    return;
-                }
-                else
-                {
-                    _hub.AddBreadcrumb(null,
-                        "navigation",
-                        "navigation",
-                        new Dictionary<string, string> { { "from", $"/{CurrentPage}" }, { "to", $"/{pageType.Name}" } });
-                }
-            }
-            CurrentPage = pageType.Name;
-        }
+        private void Current_RequestedThemeChanged(object sender, AppThemeChangedEventArgs themeEvent)
+            => _hub?.AddBreadcrumb(themeEvent.RequestedTheme.ToString(), "AppTheme.Change", level: BreadcrumbLevel.Info);
     }
 }

--- a/Src/Sentry.Xamarin/Extensions/SentryXamarinOptionsExtensions.cs
+++ b/Src/Sentry.Xamarin/Extensions/SentryXamarinOptionsExtensions.cs
@@ -100,11 +100,16 @@ namespace Sentry
             return false;
         }
 
+        /// <summary>
+        /// Unregister the previous navigation tracker and adds the registers the new Navigation Tracker to SentryXamarinOptions.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="tracker">The IPageNavigationTracker.</param>
         internal static void AddPageNavigationTrackerIntegration(this SentryXamarinOptions options, IPageNavigationTracker tracker)
         {
-            tracker.RegisterXamarinOptions(options);
-            options.PageTracker = tracker;
             options.AddIntegration(tracker);
+            options.PageTracker?.Unregister();
+            options.PageTracker = tracker;
         }
 
         internal static void RegisterXamarinInAppExclude(this SentryXamarinOptions options)

--- a/Src/Sentry.Xamarin/Internals/IPageNavigationTracker.cs
+++ b/Src/Sentry.Xamarin/Internals/IPageNavigationTracker.cs
@@ -2,10 +2,19 @@
 
 namespace Sentry.Xamarin.Internals
 {
+    /// <summary>
+    /// Interface that should be implemented to track the page navigation on an app.
+    /// </summary>
     interface IPageNavigationTracker : ISdkIntegration
     {
+        /// <summary>
+        /// The name of the current page on the application.
+        /// </summary>
         public string CurrentPage { get; }
 
-        public void RegisterXamarinOptions(SentryXamarinOptions options);
+        /// <summary>
+        /// Disable the navigation code.
+        /// </summary>
+        public void Unregister();
     }
 }

--- a/Tests/Sentry.Xamarin.Forms.UWP.Tests/Internals/FormsApplicationListenerTests.cs
+++ b/Tests/Sentry.Xamarin.Forms.UWP.Tests/Internals/FormsApplicationListenerTests.cs
@@ -1,21 +1,19 @@
 ﻿using Sentry.Xamarin.Forms.Internals;
 using Sentry.Xamarin.Forms.Testing.Mock;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using Xamarin.Forms;
 using Xunit;
 
 namespace Sentry.Xamarin.Forms.UWP.Tests.Internals
 {
-    public class SentryXamarinFormsIntegrationTests
+    public class FormsApplicationListenerTests
     {
         [Fact]
-        public async Task Register_FormsNotInitialized_IgnoreIntegration()
+        // Test
+        public async Task Register_FormsNotInitialized_HooksNotInvoked()
         {
             //Assert
-            var integration = new SentryXamarinFormsIntegration();
             var mockDiagnostic = new MockDiagnosticLogger(SentryLevel.Debug);
             var options = new SentryXamarinOptions()
             {
@@ -24,12 +22,14 @@ namespace Sentry.Xamarin.Forms.UWP.Tests.Internals
                 GetCurrentApplicationDelay = 1,
                 GetCurrentApplicationMaxRetries = 1
             };
+            var integration = new FormsApplicationListener(options);
             var mockHub = new MockHub();
-            integration.RegisterXamarinOptions(options);
+            Action<Application> badListener = (_) => throw null;
+            integration.AddListener(badListener);
 
             //Act
-            integration.Register(mockHub, options);
-            SentryXamarinFormsIntegration.Instance = null;
+            integration.Invoke();
+
             await Task.Delay(options.GetCurrentApplicationDelay + 100);
 
             //Assert
@@ -40,29 +40,24 @@ namespace Sentry.Xamarin.Forms.UWP.Tests.Internals
         public async Task Register_FormsNotInitializedAndWithoutLogger_IgnoreIntegration()
         {
             //Assert
-            var integration = new SentryXamarinFormsIntegration();
             var options = new SentryXamarinOptions()
             {
                 GetCurrentApplicationDelay = 1,
                 GetCurrentApplicationMaxRetries = 1
             };
-            integration.RegisterXamarinOptions(options);
+            var integration = new FormsApplicationListener(options);
             var mockHub = new MockHub();
+            Action<Application> badListener = (_) => throw null;
+            integration.AddListener(badListener);
 
             //Act
-            try
-            {
+            integration.Invoke();
 
-                integration.Register(mockHub, options);
-                SentryXamarinFormsIntegration.Instance = null;
-                await Task.Delay(options.GetCurrentApplicationDelay + 15);
-            }
-            catch(Exception)
-            {
-                throw;
-            }
+            await Task.Delay(options.GetCurrentApplicationDelay + 100);
 
             //Assert
+
         }
+
     }
 }

--- a/Tests/Sentry.Xamarin.Forms.UWP.Tests/Sentry.Xamarin.Forms.UWP.Tests.csproj
+++ b/Tests/Sentry.Xamarin.Forms.UWP.Tests/Sentry.Xamarin.Forms.UWP.Tests.csproj
@@ -120,10 +120,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions\SentryXamarinOptionsExtensionsTests.cs" />
+    <Compile Include="Internals\FormsApplicationListenerTests.cs" />
     <Compile Include="Internals\XamarinEventProcessorTests.cs" />
     <Compile Include="Internals\NativeEventProcessorTests.cs" />
     <Compile Include="Internals\NativeIntegrationTests.cs" />
-    <Compile Include="Internals\SentryXamarinFormsIntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SentryXamarinIntegrationTests.cs" />
     <Compile Include="UnitTestApp.xaml.cs">


### PR DESCRIPTION
- Add SentryOptions extension: RemoveNavigationPageIntegration
- Isolated the logic to receive the Application.Current
- refactored the Xamarin Forms integration, isolating the navigation integration from the rest of the Xamarin Forms integration.