### PR TITLE
Fix 0 byte screenshot being sent to Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Fix 0 byte screenshot being sent to Sentry ([#111](https://github.com/getsentry/sentry-xamarin/pull/111))
 - Ignore null data on Internal breadcrumbs ([#90](https://github.com/getsentry/sentry-xamarin/pull/90))
 - Update Sentry.NET SDK to 3.16.0 ([#110](https://github.com/getsentry/sentry-xamarin/pull/110))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.16.0/CHANGELOG.md)

--- a/Src/Sentry.Xamarin/Extensions/SentryXamarinOptionsExtensions.cs
+++ b/Src/Sentry.Xamarin/Extensions/SentryXamarinOptionsExtensions.cs
@@ -68,7 +68,7 @@ namespace Sentry
             if (options.AttachScreenshots)
             {
                 SentrySdk.ConfigureScope(s => 
-                    s.AddAttachment(new ScreenshotAttachment(new ScreenshotAttachmentContent(options))));
+                    s.AddAttachment(new ScreenshotAttachment(new ScreenshotAttachmentContent())));
             }
 #endif
         }

--- a/Src/Sentry.Xamarin/Internals/Device/Screenshot/ScreenshotAttachmentContent.cs
+++ b/Src/Sentry.Xamarin/Internals/Device/Screenshot/ScreenshotAttachmentContent.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using Sentry.Extensibility;
+﻿using System.IO;
 using Xamarin.Essentials;
 using static Xamarin.Essentials.Screenshot;
 
@@ -8,21 +6,10 @@ namespace Sentry.Internals.Device.Screenshot
 {
     internal class ScreenshotAttachmentContent : IAttachmentContent
     {
-        private SentryXamarinOptions _options { get; }
-        public ScreenshotAttachmentContent(SentryXamarinOptions options) => _options = options;
-
         public Stream GetStream()
         {
-            try
-            {
                 var screenStream = CaptureAsync().ConfigureAwait(false).GetAwaiter().GetResult();
                 return screenStream.OpenReadAsync(ScreenshotFormat.Jpeg).ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                _options.DiagnosticLogger?.LogError("Failed to capture a screenshot.", ex);
-            }
-            return new MemoryStream();
         }
     }
 }


### PR DESCRIPTION
- The new behavior will drop the screenshot in case of a failure instead of creating an empty screenshot.

Fixes #86