### PR TITLE
adjust DSN for Android.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- adjust DSN for Android ([#114](https://github.com/getsentry/sentry-xamarin/pull/114))
+- Adjust DSN for Android by dropping oProj.ingest from the URL. This works around the LetsEncrypt root certificate issue by hitting a different endpoint that doesn't use LetsEncrypt. ([#114](https://github.com/getsentry/sentry-xamarin/pull/114))
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- adjust DSN for Android ([#114](https://github.com/getsentry/sentry-xamarin/pull/114))
+
 ## 1.4.0
 
 ### Features

--- a/Samples/Sample.Xamarin.Droid/MainActivity.cs
+++ b/Samples/Sample.Xamarin.Droid/MainActivity.cs
@@ -17,7 +17,7 @@ namespace Sample.Xamarin.Droid
         {
             SentryXamarin.Init(options =>
             {
-                options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@sentry.io/5560112";
+                options.Dsn = "https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112";
                 options.AddXamarinFormsIntegration();
                 options.Debug = true;
                 options.AttachScreenshots = true;

--- a/Src/Sentry.Xamarin/Extensions/SentryXamarinOptionsExtensions.cs
+++ b/Src/Sentry.Xamarin/Extensions/SentryXamarinOptionsExtensions.cs
@@ -71,7 +71,7 @@ namespace Sentry
             // Instead of users altering their DSN on their code to use an alternative DSN
             // We'll alter their DSN to the alternative one that works with Xamarin Android.
             // More information: https://github.com/xamarin/xamarin-android/issues/6351
-            => options.Dsn = options.Dsn is not null ? Regex.Replace(options.Dsn, "@.*.ingest.sentry", "@sentry") : null;
+            => options.Dsn = options.Dsn is not null ? Regex.Replace(options.Dsn, "@o\\d+\\.ingest\\.sentry", "@sentry") : null;
 
         internal static void RegisterXamarinEventProcessors(this SentryXamarinOptions options)
         {

--- a/Tests/Sentry.Xamarin.Tests/Extensions/SentryXamarinOptionsExtensionsTests.cs
+++ b/Tests/Sentry.Xamarin.Tests/Extensions/SentryXamarinOptionsExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using Xunit;
+
+namespace Sentry.Xamarin.Tests.Extensions
+{
+    public class SentryXamarinOptionsExtensionsTests
+    {
+
+        [InlineData("https://5a193123a9b841bc8d8e42531e7242a1@sentry.io/5560112", "https://5a193123a9b841bc8d8e42531e7242a1@sentry.io/5560112")]
+        [InlineData("https://5a193123a9b841bc8d8e42531e7242a1@o447951.ingest.sentry.io/5560112", "https://5a193123a9b841bc8d8e42531e7242a1@sentry.io/5560112")]
+        [InlineData("https://5a193123a9b841bc8d8e42531e7242a1@aliens.ufo/5560112", "https://5a193123a9b841bc8d8e42531e7242a1@aliens.ufo/5560112")]
+        [InlineData("badDsn", "badDsn")]
+        [InlineData(null, null)]
+        [Theory]
+        public void AdjustSaasDsn_AndroidDsn_AlternativeDsnSet(string dsn, string expectedDsn)
+        {
+            // Arrange
+            var options = new SentryXamarinOptions()
+            {
+                Dsn = dsn
+            };
+
+            // Act
+            options.AdjustSaasDsn();
+
+            // Assert
+            Assert.Equal(expectedDsn, options.Dsn);
+        }
+    }
+}

--- a/Tests/Sentry.Xamarin.Tests/Sentry.Xamarin.Tests.csproj
+++ b/Tests/Sentry.Xamarin.Tests/Sentry.Xamarin.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  <TargetFramework>netcoreapp3.1</TargetFramework>
+  <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <!-- https://github.com/tonerdo/coverlet/issues/33#issuecomment-382748414 -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
This additional step alters the current  DSN  on Android if ran on Saas to use the alternative URL in order to communicate with the server to avoid https://github.com/mono/mono/issues/21233

Fixes #107