### PR TITLE
Rollback: Update logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 <p align="center">
   <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-    <picture>
-      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" media="(prefers-color-scheme: dark)" />
-      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
       <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" width="280">
-    </picture>
   </a>
 </p>
 


### PR DESCRIPTION
As stated on https://github.com/getsentry/sentry-capacitor/pull/168

In https://github.com/getsentry/sentry-capacitor/pull/167, I updated the logo to use white or black based on theme. While this works well for GitHub, it was pointed out to me that we also render these readme files on package registries, and some (including NPM) do not set their theme correctly. (See https://github.com/getsentry/sentry-electron/pull/479#issuecomment-1118755203)

Updating to use the purple Sentry logo instead, which renders well on both white and black backgrounds, and will work for both GitHub and NPM.

Sorry for the friction.

#skip-changelog