### PR TITLE
Update readme and include in nuget package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
-<p align="center">
-  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-    <picture>
-      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" media="(prefers-color-scheme: dark)" />
-      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
-      <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" width="280">
-    </picture>
-  </a>
-</p>
+[![Sentry](https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png)](https://sentry.io/?utm_source=github&utm_medium=logo)
 
-_Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
+_Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us, [**check out our open positions**](https://sentry.io/careers/)._
  
 Sentry SDK for Xamarin
 ===========
@@ -37,16 +29,12 @@ Additionaly, Android and IOS will include additional information:
 * Free Internal memory (Android/iOS).
 * Total RAM (Android/iOS).
 * CPU model (Android).
-<p align="center">
-  <b>BEFORE</b>
-  
-  <img src=".github/before_01.png"/>
-</p>
-<p align="center">
-  <b>AFTER</b>
-  
-  <img src=".github/after_01.png"/>
-</p>
+
+### BEFORE
+![Screenshot of Sentry before applying Sentry.Xamarin](https://github.com/getsentry/sentry-xamarin/raw/main/.github/before_01.png)
+
+### AFTER
+![Screenshot of Sentry after applying Sentry.Xamarin](https://github.com/getsentry/sentry-xamarin/raw/main/.github/after_01.png)
 
 ## Setup
 All you need to do is to initialize Xamarin integration by calling SentryXamarin.Init, and, it's recommended to start Sentry Xamarin SDK as early as possible, for an example, the start of OnCreate on MainActivity for Android, and, the top of FinishedLaunching on AppDelegate for iOS)

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -49,8 +49,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
-    <None Include="../../README.md" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
+    <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -22,6 +22,7 @@
     <PackageIcon>sentry-nuget.png</PackageIcon>
     <PackageProjectUrl>https://sentry.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <PackageReleaseNotes>Can be found at: https://github.com/getsentry/sentry-xamarin/releases</PackageReleaseNotes>
 

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -23,6 +23,8 @@
     <PackageProjectUrl>https://sentry.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    
+    <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath=""/>
 
     <PackageReleaseNotes>Can be found at: https://github.com/getsentry/sentry-xamarin/releases</PackageReleaseNotes>
 

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -23,8 +23,6 @@
     <PackageProjectUrl>https://sentry.io</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    
-    <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath=""/>
 
     <PackageReleaseNotes>Can be found at: https://github.com/getsentry/sentry-xamarin/releases</PackageReleaseNotes>
 
@@ -52,6 +50,7 @@
 
   <ItemGroup>
     <None Include="../../.assets/sentry-nuget.png" Pack="true" PackagePath=""/>
+    <None Include="../../README.md" Pack="true" PackagePath=""/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR does the following:

- Includes the readme file in the nuget package, like we do already for sentry-dotnet.  This will let it be visible at https://www.nuget.org/packages/Sentry.Xamarin/ instead of just the description text. (on next publish)
- Removes all HTML from the readme, as nuget won't render HTML
- Switches to the purple Sentry logo, which is readable on both white and black backgrounds

See also #116 & #117.

#skip-changelog
