### PR TITLE
Bump Sentry .NET 3.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Adjust DSN for Android by dropping oProj.ingest from the URL. This works around the LetsEncrypt root certificate issue by hitting a different endpoint that doesn't use LetsEncrypt. ([#114](https://github.com/getsentry/sentry-xamarin/pull/114))
-- Update Sentry.NET SDK to 3.17.1 ([#?](https://github.com/getsentry/sentry-xamarin/pull/?))
+- Update Sentry.NET SDK to 3.17.1 ([#119](https://github.com/getsentry/sentry-xamarin/pull/119))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.17.1/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.16.0...3.17.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 
 - Adjust DSN for Android by dropping oProj.ingest from the URL. This works around the LetsEncrypt root certificate issue by hitting a different endpoint that doesn't use LetsEncrypt. ([#114](https://github.com/getsentry/sentry-xamarin/pull/114))
+- Update Sentry.NET SDK to 3.17.1 ([#?](https://github.com/getsentry/sentry-xamarin/pull/?))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.17.1/CHANGELOG.md)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.16.0...3.17.1)
 
 ## 1.4.0
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sentry" Version="3.16.0" />
+    <PackageReference Include="Sentry" Version="3.17.1" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />


### PR DESCRIPTION
The bump includes an important fix that fixes the unobservable exceptions found on #115.

Close #115