### PR TITLE
chore: Update Github Actions

### DIFF
--- a/.github/workflows/add-platform-label.yml
+++ b/.github/workflows/add-platform-label.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+      - uses: andymckay/labeler@1.0.4
         with:
           add-labels: "Platform: Xamarin"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,38 +16,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, macos-latest]
+        os: [windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: '5.0.100'
-      - uses: microsoft/setup-msbuild@v1.0.2
-        if: matrix.os == 'windows-2019'
+      - uses: actions/checkout@v3
+      - uses: microsoft/setup-msbuild@v1.1
+        if: startsWith(matrix.os, 'windows')
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
       - name: Restore iOS Sample app NuGet
         run: msbuild Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj -p:Configuration=Release -t:restore
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
       - name: Build iOS Sample app
         run: msbuild Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj -p:Configuration=Release
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
       - name: Build Android Sample app
         run: msbuild Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj -p:Configuration=Release
-        if: matrix.os == 'windows-2019'
+        if: startsWith(matrix.os, 'windows')
       - name: Build UWP Sample app
         run: msbuild Samples/Sample.Xamarin.UWP/Sample.Xamarin.UWP.csproj /p:Platform=x64 /p:Configuration=Release
-        if: matrix.os == 'windows-2019'
+        if: startsWith(matrix.os, 'windows')
       - name: Build UWP Test Project
         run: msbuild Tests/Sentry.Xamarin.Forms.UWP.Tests/Sentry.Xamarin.Forms.UWP.Tests.csproj /p:Platform=x64 /p:Configuration=Release
-        if: matrix.os == 'windows-2019'
+        if: startsWith(matrix.os, 'windows')
       - name: Setup VS Test
         uses: darenm/Setup-VSTest@v1
-        if: matrix.os == 'windows-2019'
+        if: startsWith(matrix.os, 'windows')
       - name: Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [windows-2019, macos-latest] # Stay on 2019 for Windows SDK Version 10.0.16299.0
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,7 +8,7 @@ jobs:
     name: Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - run: npx danger ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: 'Release a new version: ${{ github.event.inputs.version }}'
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0


### PR DESCRIPTION
- Update all GitHub actions to their current versions
- Add a comment about why we need to stay on `windows-2019`
  - `windows-latest` doesn't have the older Windows SDK version we're targeting
  - Use `startsWith` in conditional tests, to reduce number of places to update in the future
- Remove the manual install of .NET 5.  We'll use the pre-installed version from the virtual environment.
  - Note, that we were installing 5.0.100, which is quite old now.  Among other things, that was preventing the readme file from actually make it into the `<readme>` tag in the generated .nuspec file within the nuget package, as `<PackageReadmeFile>` tooling was added in 5.0.300.
 
#skip-changelog