### PR TITLE
Avoid repeat initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Avoid repeat initialization ([#130](https://github.com/getsentry/sentry-xamarin/pull/130))
+
 ## 1.4.4
 
 ### Fixes

--- a/Src/Sentry.Xamarin/SentryXamarin.cs
+++ b/Src/Sentry.Xamarin/SentryXamarin.cs
@@ -21,6 +21,12 @@ namespace Sentry
         /// <param name="configureOptions">The configure options.</param>
         public static void Init(Action<SentryXamarinOptions> configureOptions)
         {
+            if (SentrySdk.IsEnabled)
+            {
+                Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+                return;
+            }
+
             var options = new SentryXamarinOptions();
             // Set the release now but give the user a chance to reset it (i.e: to null to rely on the built-in format)
             options.Release = $"{AppInfo.PackageName}@{AppInfo.VersionString}+{AppInfo.BuildString}";

--- a/Src/Sentry.Xamarin/SentryXamarin.cs
+++ b/Src/Sentry.Xamarin/SentryXamarin.cs
@@ -21,14 +21,6 @@ namespace Sentry
         /// <param name="configureOptions">The configure options.</param>
         public static void Init(Action<SentryXamarinOptions> configureOptions)
         {
-            if (SentrySdk.IsEnabled)
-            {
-                if (configureOptions.Debug) {
-                    Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
-                }
-                return;
-            }
-
             var options = new SentryXamarinOptions();
             // Set the release now but give the user a chance to reset it (i.e: to null to rely on the built-in format)
             options.Release = $"{AppInfo.PackageName}@{AppInfo.VersionString}+{AppInfo.BuildString}";
@@ -51,11 +43,12 @@ namespace Sentry
         /// <param name="options">The options instance</param>
         public static void Init(SentryXamarinOptions options)
         {
-                if (options.Debug) {
-                    Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
-                }
+            if (SentrySdk.IsEnabled)
             {
-                Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+                options.DiagnosticLogger?.Log(
+                    SentryLevel.Warning,
+                    "SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+
                 return;
             }
 

--- a/Src/Sentry.Xamarin/SentryXamarin.cs
+++ b/Src/Sentry.Xamarin/SentryXamarin.cs
@@ -49,6 +49,12 @@ namespace Sentry
         /// <param name="options">The options instance</param>
         public static void Init(SentryXamarinOptions options)
         {
+            if (SentrySdk.IsEnabled)
+            {
+                Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+                return;
+            }
+
             SentrySdk.Init(options);
 
             options.RegisterScreenshotEventProcessor();

--- a/Src/Sentry.Xamarin/SentryXamarin.cs
+++ b/Src/Sentry.Xamarin/SentryXamarin.cs
@@ -51,7 +51,9 @@ namespace Sentry
         /// <param name="options">The options instance</param>
         public static void Init(SentryXamarinOptions options)
         {
-            if (SentrySdk.IsEnabled)
+                if (options.Debug) {
+                    Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+                }
             {
                 Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
                 return;

--- a/Src/Sentry.Xamarin/SentryXamarin.cs
+++ b/Src/Sentry.Xamarin/SentryXamarin.cs
@@ -23,7 +23,9 @@ namespace Sentry
         {
             if (SentrySdk.IsEnabled)
             {
-                Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+                if (configureOptions.Debug) {
+                    Console.Error.WriteLine("SentryXamarin.Init was called again. It should only be called once. Any change to options will be ignored.");
+                }
                 return;
             }
 


### PR DESCRIPTION
Fixes #129 by automatically preventing multiple initialization.  Writes a message to stderr accordingly.

Will continue pursuing a fix for the root cause in https://github.com/getsentry/sentry-dotnet/issues/2033.