### PR TITLE
Bump Sentry dotnet 3.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixes
 
-  - Update Sentry.NET SDK to 3.26.1 ([#133](https://github.com/getsentry/sentry-xamarin/pull/133))
-  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.26.1/CHANGELOG.md)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.23.1...3.26.1)
+  - Update Sentry.NET SDK to 3.26.2 ([#133](https://github.com/getsentry/sentry-xamarin/pull/133))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.26.2/CHANGELOG.md)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.23.1...3.26.2)
   
 ## 1.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Fixes
 
-  - Update Sentry.NET SDK to 3.26.1 ([#128](https://github.com/getsentry/sentry-xamarin/pull/128))
+  - Update Sentry.NET SDK to 3.26.1 ([#133](https://github.com/getsentry/sentry-xamarin/pull/133))
   - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.26.1/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.23.1...3.26.1)
+  
 ## 1.4.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+  - Update Sentry.NET SDK to 3.26.1 ([#128](https://github.com/getsentry/sentry-xamarin/pull/128))
+  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.26.1/CHANGELOG.md)
+  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.23.1...3.26.1)
+
 ## 1.4.4
 
 ### Fixes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sentry" Version="3.26.1" />
+    <PackageReference Include="Sentry" Version="3.26.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sentry" Version="3.23.1" />
+    <PackageReference Include="Sentry" Version="3.26.1" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />


### PR DESCRIPTION
This PR bumps Sentry .NET SDK to version 3.26.2