### PR TITLE
Update Sentry.NET SDK to 3.27.0 and support symbolication on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-  - Update Sentry.NET SDK to 3.27.0, which supports line numbers for Android ([#135](https://github.com/getsentry/sentry-xamarin/pull/133))
+  - Update Sentry.NET SDK to 3.27.0, which supports line numbers for Android ([#135](https://github.com/getsentry/sentry-xamarin/pull/135))
     - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.27.0/CHANGELOG.md)
     - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.26.2...3.27.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## 1.5.0
+
+### Features
+
+  - Update Sentry.NET SDK to 3.27.0, which supports line numbers for Android ([#135](https://github.com/getsentry/sentry-xamarin/pull/133))
+    - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.27.0/CHANGELOG.md)
+    - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.26.2...3.27.0)
+
 ## 1.4.6
 
 ### Fixes
 
   - Update Sentry.NET SDK to 3.26.2 ([#133](https://github.com/getsentry/sentry-xamarin/pull/133))
-  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.26.2/CHANGELOG.md)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.23.1...3.26.2)
+    - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.26.2/CHANGELOG.md)
+    - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.23.1...3.26.2)
 
 ## 1.4.5
 
@@ -19,24 +27,24 @@
 ### Fixes
 
   - Update Sentry.NET SDK to 3.23.1 ([#128](https://github.com/getsentry/sentry-xamarin/pull/128))
-  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.23.1/CHANGELOG.md)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.22.0...3.23.1)
+    - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.23.1/CHANGELOG.md)
+    - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.22.0...3.23.1)
 
 ## 1.4.3
 
 ### Fixes
 
   - Update Sentry.NET SDK to 3.22.0 ([#127](https://github.com/getsentry/sentry-xamarin/pull/127))
-  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.22.0/CHANGELOG.md)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.20.1...3.22.0)
+    - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.22.0/CHANGELOG.md)
+   - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.20.1...3.22.0)
 
 ## 1.4.2
 
 ### Fixes
 
   - Update Sentry.NET SDK to 3.20.1 ([#125](https://github.com/getsentry/sentry-xamarin/pull/125))
-  - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.20.1/CHANGELOG.md)
-  - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.17.1...3.20.1)
+    - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.20.1/CHANGELOG.md)
+    - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.17.1...3.20.1)
 
 ## 1.4.1
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sentry" Version="3.26.2" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.1" PrivateAssets="All" />

--- a/README.md
+++ b/README.md
@@ -107,11 +107,6 @@ The package requires the following versions or newer:
 * Xamarin.Essentials 1.4.0
 * Sentry 3.0.0
 
-
-## Limitations
-
-There are no line numbers on stack traces for UWP and in release builds for Android and iOS, furthermore, mono symbolication is not yet supported.
-
 ## Resources
 
 * [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/dotnet/)

--- a/Src/Sentry.Xamarin.Forms/Sentry.Xamarin.Forms.csproj
+++ b/Src/Sentry.Xamarin.Forms/Sentry.Xamarin.Forms.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Sentry.Xamarin\Sentry.Xamarin.csproj" />
 	<PackageReference Include="Xamarin.Forms" Version="4.6.0.726" />
-	<PackageReference Remove="Sentry" />
   </ItemGroup>
 	
   <ItemGroup Condition="$(TargetFramework.StartsWith('uap'))">

--- a/Src/Sentry.Xamarin/Internals/SentryAndroidHelpers.droid.cs
+++ b/Src/Sentry.Xamarin/Internals/SentryAndroidHelpers.droid.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Sentry.Android.AssemblyReader;
+using Sentry.Extensibility;
+
+using Appliction = Android.App.Application;
+using AndroidBuild = Android.OS.Build;
+
+namespace Sentry.Xamarin.Internals
+{
+    internal static class SentryAndroidHelpers
+    {
+        public static IList<string> GetSupportedAbis()
+        {
+            var result = AndroidBuild.SupportedAbis;
+            if (result != null)
+            {
+                return result;
+            }
+
+#pragma warning disable CS0618
+            var abi = AndroidBuild.CpuAbi;
+#pragma warning restore CS0618
+
+            return abi != null ? new[] {abi} : Array.Empty<string>();
+        }
+
+        public static IAndroidAssemblyReader? GetAndroidAssemblyReader(IDiagnosticLogger? logger)
+        {
+            var apkPath = Appliction.Context.ApplicationInfo?.SourceDir;
+            if (apkPath == null)
+            {
+                logger?.LogWarning("Can't determine APK path.");
+                return null;
+            }
+
+            if (!File.Exists(apkPath))
+            {
+                logger?.LogWarning("APK doesn't exist at {0}", apkPath);
+                return null;
+            }
+
+            try
+            {
+                var supportedAbis = GetSupportedAbis();
+                return AndroidAssemblyReaderFactory.Open(apkPath, supportedAbis,
+                    logger: (message, args) => logger?.Log(SentryLevel.Debug, message, args: args));
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError("Cannot create assembly reader.", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -43,6 +43,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Sentry" Version="3.27.0" />
+		<PackageReference Include="Sentry.Android.AssemblyReader" Version="1.0.0" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
 	</ItemGroup>
 

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -42,6 +42,7 @@
 	</ItemGroup>	
 
 	<ItemGroup>
+		<PackageReference Include="Sentry" Version="3.27.0" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
 	</ItemGroup>
 

--- a/Src/Sentry.Xamarin/SentryXamarinOptions.cs
+++ b/Src/Sentry.Xamarin/SentryXamarinOptions.cs
@@ -1,6 +1,11 @@
 ﻿using Sentry.Internals.Session;
 using Sentry.Xamarin.Internals;
 
+#if __ANDROID__
+using System;
+using Sentry.Android.AssemblyReader;
+#endif
+
 namespace Sentry
 {
     /// <summary>
@@ -46,6 +51,12 @@ namespace Sentry
             IsEnvironmentUser = false;
             AutoSessionTracking = true;
             IsGlobalModeEnabled = true;
+
+#if __ANDROID__
+            var reader = new Lazy<IAndroidAssemblyReader?>(() =>
+                SentryAndroidHelpers.GetAndroidAssemblyReader(DiagnosticLogger));
+            AssemblyReader = name => reader.Value?.TryReadAssembly(name);
+#endif
         }
     }
 }


### PR DESCRIPTION
- Updates Sentry to 3.27.0
- Adds the `Sentry.AndroidAssemblyReader` as a dependency for Android targets, allowing symbolication of line numbers on Android.  Resolves #134