### PR TITLE
Update Sentry to 3.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+  - Update Sentry.NET SDK to 3.27.1 ([#136](https://github.com/getsentry/sentry-xamarin/pull/136))
+    - [changelog](https://github.com/getsentry/sentry-dotnet/blob/3.27.1/CHANGELOG.md)
+    - [diff](https://github.com/getsentry/sentry-dotnet/compare/3.27.0...3.27.1)
+
 ## 1.5.0
 
 ### Features

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -42,7 +42,7 @@
 	</ItemGroup>	
 
 	<ItemGroup>
-		<PackageReference Include="Sentry" Version="3.27.0" />
+		<PackageReference Include="Sentry" Version="3.27.1" />
 		<PackageReference Include="Sentry.Android.AssemblyReader" Version="1.0.0" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
 	</ItemGroup>


### PR DESCRIPTION
Fixes issue with Sentry CLI MSBuild Integration for Xamarin