### PR TITLE
Bump Sentry.NET 4.0.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,13 +31,15 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: '11'
+          distribution: 'microsoft'
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3.2.0
-
+        with:
+          packages: 'platforms;android-30'
+          
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
       - name: Restore iOS Sample app NuGet

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: microsoft/setup-msbuild@v1.1
         if: startsWith(matrix.os, 'windows')
         # By default, the latest Windows machine doesn't come with the 16299 SDK installed,
@@ -31,9 +31,13 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: actions/setup-java@v4
         with:
-          distribution: 'microsoft'
-          java-version: '11'
+          java-version: '17'
+          distribution: 'temurin'
       - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3.2.0
+
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release
       - name: Restore iOS Sample app NuGet

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,12 +33,13 @@ jobs:
         with:
           java-version: '11'
           distribution: 'microsoft'
-      - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3.2.0
         with:
           packages: 'platforms;android-30'
+
+      - run: msbuild Sentry.Xamarin.sln -p:Configuration=Release -t:restore
           
       - name: Build Solution with MSBuild
         run: msbuild Sentry.Xamarin.sln -p:Configuration=Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,12 +28,12 @@ jobs:
             pwsh ./scripts/install-win-sdk.ps1 16299
         if: startsWith(matrix.os, 'windows')
       - name: Setup Java SDK
-        if: startsWith(matrix.os, 'windows')
+
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'microsoft'
-
+          distribution: 'temurin'
+          java-version: '17'
+          
       - name: Setup Android SDK
         uses: android-actions/setup-android@07976c6290703d34c16d382cb36445f98bb43b1f # v3.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: 'Release a new version: ${{ github.event.inputs.version }}'
     steps:
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ If you have compilation errors you can find the affected types or overloads miss
 
 ### Android breaking Changes
 
-- Android minimum support increased to API 30  ([#2697](https://github.com/getsentry/sentry-dotnet/pull/2697))
+- Android minimum support increased to API 30 by requiring Mono.Android 11.0 instead of Mono.Android 9.0.   ([#2697](https://github.com/getsentry/sentry-dotnet/pull/2697))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ If you have compilation errors you can find the affected types or overloads miss
   });
   ```
 
+### Android breaking Changes
+
+- Android minimum support increased to API 30  ([#2697](https://github.com/getsentry/sentry-dotnet/pull/2697))
+
 ### Features
 
 - Added `Xamarin.Mac` support ([#138](https://github.com/getsentry/sentry-xamarin/pull/138))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,153 @@
 # Changelog
 
+## Unreleased
+
+### Sentry Self-hosted Compatibility
+
+If you're using `sentry.io` this change does not affect you.
+This SDK version is compatible with a self-hosted version of Sentry `22.12.0` or higher. If you are using an older version of [self-hosted Sentry](https://develop.sentry.dev/self-hosted/) (aka on-premise), you will need to [upgrade](https://develop.sentry.dev/self-hosted/releases/). 
+
+### Significant change in behavior
+
+- Transaction names for ASP.NET Core are now consistently named `HTTP-VERB /path` (e.g. `GET /home`). Previously, the leading forward slash was missing for some endpoints. ([#2808](https://github.com/getsentry/sentry-dotnet/pull/2808))
+- Setting `SentryOptions.Dsn` to `null` now throws `ArgumentNullException` during initialization. ([#2655](https://github.com/getsentry/sentry-dotnet/pull/2655))
+- Enable `CaptureFailedRequests` by default ([#2688](https://github.com/getsentry/sentry-dotnet/pull/2688))
+- Added `Sentry` namespace to global usings when `ImplicitUsings` is enabled ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
+If you have conflicts, you can opt out by adding the following to your `csproj`:
+```
+<PropertyGroup>
+  <SentryImplicitUsings>false</SentryImplicitUsings>
+</PropertyGroup>
+```
+- Transactions' spans are no longer automatically finished with the status `deadline_exceeded` by the transaction. This is now handled by the [Relay](https://github.com/getsentry/relay). 
+  - Customers self hosting Sentry must use verion 22.12.0 or later ([#3013](https://github.com/getsentry/sentry-dotnet/pull/3013))
+- The `User.IpAddress` is now set to `{{auto}}` by default, even when sendDefaultPII is disabled ([#2981](https://github.com/getsentry/sentry-dotnet/pull/2981))
+  - The "Prevent Storing of IP Addresses" option in the "Security & Privacy" project settings on sentry.io can be used to control this instead
+- The `DiagnosticLogger` signature for `LogWarning` changed to take the `exception` as the first parameter. That way it no longer gets mixed up with the TArgs. ([#2987](https://github.com/getsentry/sentry-dotnet/pull/2987))
+
+### API breaking Changes
+
+If you have compilation errors you can find the affected types or overloads missing in the changelog entries below.
+
+#### Changed APIs
+
+- Class renamed `Sentry.User` to `Sentry.SentryUser` ([#3015](https://github.com/getsentry/sentry-dotnet/pull/3015))
+- Class renamed `Sentry.Runtime` to `Sentry.SentryRuntime` ([#3016](https://github.com/getsentry/sentry-dotnet/pull/3016))
+- Class renamed `Sentry.Span` to `Sentry.SentrySpan` ([#3021](https://github.com/getsentry/sentry-dotnet/pull/3021))
+- Class renamed `Sentry.Transaction` to `Sentry.SentryTransaction` ([#3023](https://github.com/getsentry/sentry-dotnet/pull/3023))
+- `ITransaction` has been renamed to `ITransactionTracer`. You will need to update any references to these interfaces in your code to use the new interface names ([#2731](https://github.com/getsentry/sentry-dotnet/pull/2731), [#2870](https://github.com/getsentry/sentry-dotnet/pull/2870))
+- `DebugImage` and `DebugMeta` moved to `Sentry.Protocol` namespace. ([#2815](https://github.com/getsentry/sentry-dotnet/pull/2815))
+- `SentryClient.Dispose` is no longer obsolete ([#2842](https://github.com/getsentry/sentry-dotnet/pull/2842))
+- `ISentryClient.CaptureEvent` overloads have been replaced by a single method accepting optional `Hint` and `Scope` parameters. You will need to pass `hint` as a named parameter from code that calls `CaptureEvent` without passing a `scope` argument. ([#2749](https://github.com/getsentry/sentry-dotnet/pull/2749))
+- `TransactionContext` and `SpanContext` constructors were updated. If you're constructing instances of these classes, you will need to adjust the order in which you pass parameters to these. ([#2694](https://github.com/getsentry/sentry-dotnet/pull/2694), [#2696](https://github.com/getsentry/sentry-dotnet/pull/2696))
+- The `DiagnosticLogger` signature for `LogError` and `LogFatal` changed to take the `exception` as the first parameter. That way it no longer gets mixed up with the TArgs. The `DiagnosticLogger` now also receives an overload for `LogError` and `LogFatal` that accepts a message only. ([#2715](https://github.com/getsentry/sentry-dotnet/pull/2715))
+- `Distribution` added to `IEventLike`. ([#2660](https://github.com/getsentry/sentry-dotnet/pull/2660))
+- `StackFrame`'s `ImageAddress`, `InstructionAddress`, and `FunctionId` changed to `long?`. ([#2691](https://github.com/getsentry/sentry-dotnet/pull/2691))
+- `DebugImage.ImageAddress` changed to `long?`. ([#2725](https://github.com/getsentry/sentry-dotnet/pull/2725))
+- Contexts now inherit from `IDictionary` rather than `ConcurrentDictionary`. The specific dictionary being used is an implementation detail. ([#2729](https://github.com/getsentry/sentry-dotnet/pull/2729))
+- The method used to configure a Sentry Sink for Serilog now has an additional overload. Calling `WriteTo.Sentry()` with no arguments will no longer attempt to initialize the SDK (it has optional arguments to configure the behavior of the Sink only). If you want to initialize Sentry at the same time you configure the Sentry Sink then you will need to use the overload of this method that accepts a DSN as the first parameter (e.g. `WriteTo.Sentry("https://d4d82fc1c2c4032a83f3a29aa3a3aff@fake-sentry.io:65535/2147483647")`). ([#2928](https://github.com/getsentry/sentry-dotnet/pull/2928))
+
+#### Removed APIs
+
+- SentrySinkExtensions.ConfigureSentrySerilogOptions is now internal. If you were using this method, please use one of the `SentrySinkExtensions.Sentry` extension methods instead. ([#2902](https://github.com/getsentry/sentry-dotnet/pull/2902))
+- A number of `[Obsolete]` options have been removed ([#2841](https://github.com/getsentry/sentry-dotnet/pull/2841))
+  - `BeforeSend` - use `SetBeforeSend` instead.
+  - `BeforeSendTransaction` - use `SetBeforeSendTransaction` instead.
+  - `BeforeBreadcrumb` - use `SetBeforeBreadcrumb` instead.
+  - `CreateHttpClientHandler` - use `CreateHttpMessageHandler` instead.
+  - `ReportAssemblies` - use `ReportAssembliesMode` instead.
+  - `KeepAggregateException` - this property is no longer used and has no replacement.
+  - `DisableTaskUnobservedTaskExceptionCapture` method has been renamed to `DisableUnobservedTaskExceptionCapture`.
+  - `DebugDiagnosticLogger` - use `TraceDiagnosticLogger` instead.
+- A number of iOS/Android-specific `[Obsolete]` options have been removed ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+  - `Distribution` - use `SentryOptions.Distribution` instead.
+  - `EnableAutoPerformanceTracking` - use `SetBeforeSendTransaction` instead.
+  - `EnableCoreDataTracking` - use `EnableCoreDataTracing` instead.
+  - `EnableFileIOTracking` - use `EnableFileIOTracing` instead.
+  - `EnableOutOfMemoryTracking` - use `EnableWatchdogTerminationTracking` instead.
+  - `EnableUIViewControllerTracking` - use `EnableUIViewControllerTracing` instead.
+  - `StitchAsyncCode` - no longer available.
+  - `ProfilingTracesInterval` - no longer available.
+  - `ProfilingEnabled` - use `ProfilesSampleRate` instead.
+- Obsolete `SystemClock` constructor removed, use `SystemClock.Clock` instead. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+- Obsolete `Runtime.Clone()` removed, this shouldn't have been public in the past and has no replacement. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+- Obsolete `SentryException.Data` removed, use `SentryException.Mechanism.Data` instead. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+- Obsolete `AssemblyExtensions` removed, this shouldn't have been public in the past and has no replacement. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+- Obsolete `SentryDatabaseLogging.UseBreadcrumbs()` removed, it is called automatically and has no replacement. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+- Obsolete `Scope.GetSpan()` removed, use `Span` property instead. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856))
+- Obsolete `IUserFactory` removed, use `ISentryUserFactory` instead. ([#2856](https://github.com/getsentry/sentry-dotnet/pull/2856), [#2840](https://github.com/getsentry/sentry-dotnet/pull/2840))
+- `IHasMeasurements` has been removed, use `ISpanData` instead. ([#2659](https://github.com/getsentry/sentry-dotnet/pull/2659))
+- `IHasBreadcrumbs` has been removed, use `IEventLike` instead. ([#2670](https://github.com/getsentry/sentry-dotnet/pull/2670))
+- `ISpanContext` has been removed, use `ITraceContext` instead. ([#2668](https://github.com/getsentry/sentry-dotnet/pull/2668))
+- `IHasTransactionNameSource` has been removed, use `ITransactionContext` instead. ([#2654](https://github.com/getsentry/sentry-dotnet/pull/2654))
+- ([#2694](https://github.com/getsentry/sentry-dotnet/pull/2694))
+- The unused `StackFrame.InstructionOffset` has been removed. ([#2691](https://github.com/getsentry/sentry-dotnet/pull/2691))
+- The unused `Scope.Platform` property has been removed. ([#2695](https://github.com/getsentry/sentry-dotnet/pull/2695))
+- The obsolete setter `Sentry.PlatformAbstractions.Runtime.Identifier` has been removed ([2764](https://github.com/getsentry/sentry-dotnet/pull/2764))
+- `Sentry.Values<T>` is now internal as it is never exposed in the public API ([#2771](https://github.com/getsentry/sentry-dotnet/pull/2771))
+- The `TracePropagationTarget` class has been removed, use the `SubstringOrRegexPattern` class instead. ([#2763](https://github.com/getsentry/sentry-dotnet/pull/2763))
+- The `WithScope` and `WithScopeAsync` methods have been removed. We have discovered that these methods didn't work correctly in certain desktop contexts, especially when using a global scope. ([#2717](https://github.com/getsentry/sentry-dotnet/pull/2717))
+
+  Replace your usage of `WithScope` with overloads of `Capture*` methods:
+
+  - `SentrySdk.CaptureEvent(SentryEvent @event, Action<Scope> scopeCallback)`
+  - `SentrySdk.CaptureMessage(string message, Action<Scope> scopeCallback)`
+  - `SentrySdk.CaptureException(Exception exception, Action<Scope> scopeCallback)`
+
+  ```c#
+  // Before
+  SentrySdk.WithScope(scope =>
+  {
+    scope.SetTag("key", "value");
+    SentrySdk.CaptureEvent(new SentryEvent());
+  });
+
+  // After
+  SentrySdk.CaptureEvent(new SentryEvent(), scope =>
+  {
+    // Configure your scope here
+    scope.SetTag("key", "value");
+  });
+  ```
+
+### Features
+
+- Added `Xamarin.Mac` support ([#138](https://github.com/getsentry/sentry-xamarin/pull/138))
+- Experimental pre-release availability of Metrics. We're exploring the use of Metrics in Sentry. The API will very likely change and we don't yet have any documentation. ([#2949](https://github.com/getsentry/sentry-dotnet/pull/2949))
+  - `SentrySdk.Metrics.Set` now additionally accepts `string` as value ([#3092](https://github.com/getsentry/sentry-dotnet/pull/3092))
+  - Timing metrics can now be captured with `SentrySdk.Metrics.StartTimer` ([#3075](https://github.com/getsentry/sentry-dotnet/pull/3075))
+  - Added support for capturing built-in metrics from the `System.Diagnostics.Metrics` API ([#3052](https://github.com/getsentry/sentry-dotnet/pull/3052))
+- `Sentry.Profiling` is now available as a package on [nuget](nuget.org). Be aware that profiling is in alpha and on servers the overhead could be high. Improving the experience for ASP.NET Core is tracked on [this issue](
+https://github.com/getsentry/sentry-dotnet/issues/2316) ([#2800](https://github.com/getsentry/sentry-dotnet/pull/2800))
+- Support for [Spotlight](https://spotlightjs.com/), a debug tool for local development. ([#2961](https://github.com/getsentry/sentry-dotnet/pull/2961))
+  - Enable it with the option `EnableSpotlight`
+  - Optionally configure the URL to connect via `SpotlightUrl`. Defaults to `http://localhost:8969/stream`.
+
+### Fixes
+
+- Native integration logging on macOS ([#3079](https://github.com/getsentry/sentry-dotnet/pull/3079))
+- The scope transaction is now correctly set for Otel transactions ([#3072](https://github.com/getsentry/sentry-dotnet/pull/3072))
+- Fixed an issue with tag values in metrics not being properly serialized ([#3065](https://github.com/getsentry/sentry-dotnet/pull/3065))
+- Moved the binding to MAUI events for breadcrumb creation from `WillFinishLaunching` to `FinishedLaunching`. This delays the initial instantiation of `app`. ([#3057](https://github.com/getsentry/sentry-dotnet/pull/3057))
+- The SDK no longer adds the `WinUIUnhandledExceptionIntegration` on non-Windows platforms ([#3055](https://github.com/getsentry/sentry-dotnet/pull/3055))
+- Stop Sentry for MacCatalyst from creating `default.profraw` in the app bundle using xcodebuild archive to build sentry-cocoa ([#2960](https://github.com/getsentry/sentry-dotnet/pull/2960))
+- Workaround a .NET 8 NativeAOT crash on transaction finish. ([#2943](https://github.com/getsentry/sentry-dotnet/pull/2943))
+- Reworked automatic breadcrumb creation for MAUI. ([#2900](https://github.com/getsentry/sentry-dotnet/pull/2900))
+  - The SDK no longer uses reflection to bind to all public element events. This also fixes issues where the SDK would consume third-party events.
+  - Added `CreateElementEventsBreadcrumbs` to the SentryMauiOptions to allow users to opt-in automatic breadcrumb creation for `BindingContextChanged`, `ChildAdded`, `ChildRemoved`, and `ParentChanged` on `Element`.
+  - Reduced amount of automatic breadcrumbs by limiting the number of bindings created in `VisualElement`, `Window`, `Shell`, `Page`, and `Button`.
+- Fixed Sentry SDK has not been initialized when using ASP.NET Core, Serilog, and OpenTelemetry ([#2911](https://github.com/getsentry/sentry-dotnet/pull/2911))
+- Android native symbol upload ([#2876](https://github.com/getsentry/sentry-dotnet/pull/2876))
+- `Sentry.Serilog` no longer throws if a disabled DSN is provided when initializing Sentry via the Serilog integration ([#2883](https://github.com/getsentry/sentry-dotnet/pull/2883))
+- Don't add WinUI exception integration on mobile platforms ([#2821](https://github.com/getsentry/sentry-dotnet/pull/2821))
+- `Transactions` are now getting enriched by the client instead of the hub ([#2838](https://github.com/getsentry/sentry-dotnet/pull/2838))
+- Fixed an issue when using the SDK together with OpenTelemetry `1.5.0` and newer where the SDK would create transactions for itself. The fix is backward compatible. ([#3001](https://github.com/getsentry/sentry-dotnet/pull/3001))
+
+### Dependencies
+
+- Upgraded to NLog version 5. ([#2697](https://github.com/getsentry/sentry-dotnet/pull/2697))
+- Bump Sentry.NET 4.0.3 ([#147](https://github.com/getsentry/sentry-xamarin/pull/147))
+
 ## 2.0.0-beta.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ This SDK version is compatible with a self-hosted version of Sentry `22.12.0` or
 
 ### Significant change in behavior
 
-- Transaction names for ASP.NET Core are now consistently named `HTTP-VERB /path` (e.g. `GET /home`). Previously, the leading forward slash was missing for some endpoints. ([#2808](https://github.com/getsentry/sentry-dotnet/pull/2808))
 - Setting `SentryOptions.Dsn` to `null` now throws `ArgumentNullException` during initialization. ([#2655](https://github.com/getsentry/sentry-dotnet/pull/2655))
 - Enable `CaptureFailedRequests` by default ([#2688](https://github.com/getsentry/sentry-dotnet/pull/2688))
 - Added `Sentry` namespace to global usings when `ImplicitUsings` is enabled ([#3043](https://github.com/getsentry/sentry-dotnet/pull/3043))
@@ -129,7 +128,6 @@ https://github.com/getsentry/sentry-dotnet/issues/2316) ([#2800](https://github.
 
 ### Fixes
 
-- Native integration logging on macOS ([#3079](https://github.com/getsentry/sentry-dotnet/pull/3079))
 - The scope transaction is now correctly set for Otel transactions ([#3072](https://github.com/getsentry/sentry-dotnet/pull/3072))
 - Fixed an issue with tag values in metrics not being properly serialized ([#3065](https://github.com/getsentry/sentry-dotnet/pull/3065))
 - Moved the binding to MAUI events for breadcrumb creation from `WillFinishLaunching` to `FinishedLaunching`. This delays the initial instantiation of `app`. ([#3057](https://github.com/getsentry/sentry-dotnet/pull/3057))
@@ -141,9 +139,7 @@ https://github.com/getsentry/sentry-dotnet/issues/2316) ([#2800](https://github.
   - Added `CreateElementEventsBreadcrumbs` to the SentryMauiOptions to allow users to opt-in automatic breadcrumb creation for `BindingContextChanged`, `ChildAdded`, `ChildRemoved`, and `ParentChanged` on `Element`.
   - Reduced amount of automatic breadcrumbs by limiting the number of bindings created in `VisualElement`, `Window`, `Shell`, `Page`, and `Button`.
 - Fixed Sentry SDK has not been initialized when using ASP.NET Core, Serilog, and OpenTelemetry ([#2911](https://github.com/getsentry/sentry-dotnet/pull/2911))
-- Android native symbol upload ([#2876](https://github.com/getsentry/sentry-dotnet/pull/2876))
 - `Sentry.Serilog` no longer throws if a disabled DSN is provided when initializing Sentry via the Serilog integration ([#2883](https://github.com/getsentry/sentry-dotnet/pull/2883))
-- Don't add WinUI exception integration on mobile platforms ([#2821](https://github.com/getsentry/sentry-dotnet/pull/2821))
 - `Transactions` are now getting enriched by the client instead of the hub ([#2838](https://github.com/getsentry/sentry-dotnet/pull/2838))
 - Fixed an issue when using the SDK together with OpenTelemetry `1.5.0` and newer where the SDK would create transactions for itself. The fix is backward compatible. ([#3001](https://github.com/getsentry/sentry-dotnet/pull/3001))
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ sealed partial class App : Application
 The package requires the following versions or newer:
 
 * Tizen 4.0 (for Tizen)
-* Xamarin.Android 9.0 (for Android)
+* Xamarin.Android 11.0 (for Android)
 * Xamarin.iOS 10.14 (for iOS)
 * Universal Windows Platform 10.0.16299 (for UWP)
 * Xamarin.Forms 4.6.0.726 (for Xamarin.Forms integration)
 * Xamarin.Essentials 1.4.0
-* Sentry 3.0.0
+* Sentry 4.0.3
 
 ## Resources
 

--- a/Src/Sentry.Xamarin/Internals/Device/Screenshot/ScreenshotAttachment.cs
+++ b/Src/Sentry.Xamarin/Internals/Device/Screenshot/ScreenshotAttachment.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sentry.Internals.Device.Screenshot
 {
-    internal class ScreenshotAttachment : Attachment
+    internal class ScreenshotAttachment : SentryAttachment
     {
         public ScreenshotAttachment(IAttachmentContent content)
         : this(

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -3,7 +3,7 @@
 	    <!--Generate xml docs for all projects under 'src'-->
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-		<TargetFrameworks>netstandard2.0;monoandroid9.0;Xamarinios10;xamarinmac20</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;monoandroid11.0;Xamarinios10;xamarinmac20</TargetFrameworks>
 		<TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);uap10.0.16299;</TargetFrameworks>
 		<NoWarn Condition="$(TargetFramework) == 'netstandard2.0'">$(NoWarn);RS0017</NoWarn>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -49,7 +49,7 @@
 	</ItemGroup>	
 
 	<ItemGroup>
-		<PackageReference Include="Sentry" Version="4.0.0-beta.5" />
+		<PackageReference Include="Sentry" Version="4.0.3" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
 	</ItemGroup>
 
@@ -67,7 +67,7 @@
 	
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid')) ">
 		<Compile Include="Internals\**\*.droid*.cs" />
-		<PackageReference Include="Sentry.Android.AssemblyReader" Version="4.0.0-beta.5" />
+		<PackageReference Include="Sentry.Android.AssemblyReader" Version="4.0.3" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('uap'))">

--- a/Tests/Sentry.Xamarin.Forms.Testing/Mock/MockHub.cs
+++ b/Tests/Sentry.Xamarin.Forms.Testing/Mock/MockHub.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Sentry.Protocol.Envelopes;
 
 namespace Sentry.Xamarin.Forms.Testing.Mock
 {
@@ -13,6 +14,8 @@ namespace Sentry.Xamarin.Forms.Testing.Mock
 
         public bool IsEnabled => true;
 
+        public IMetricAggregator Metrics => throw new NotImplementedException();
+
         public void BindClient(ISentryClient client) { }
 
         public SentryId CaptureEvent(SentryEvent evt, Action<Scope> configureScope)
@@ -21,7 +24,7 @@ namespace Sentry.Xamarin.Forms.Testing.Mock
             return evt.EventId;
         }
 
-        public void CaptureTransaction(Transaction transaction) { }
+        public void CaptureTransaction(SentryTransaction transaction) { }
 
         public void CaptureUserFeedback(UserFeedback userFeedback) { }
 
@@ -29,7 +32,7 @@ namespace Sentry.Xamarin.Forms.Testing.Mock
 
         public Task ConfigureScopeAsync(Func<Scope, Task> configureScope) => null;
 
-        public Transaction CreateTransaction(string name, string operation) => null;
+        public SentryTransaction CreateTransaction(string name, string operation) => null;
 
         public Task FlushAsync(TimeSpan timeout)
         {
@@ -68,9 +71,9 @@ namespace Sentry.Xamarin.Forms.Testing.Mock
 
         public void CaptureSession(SessionUpdate sessionUpdate) { }
 
-        public SentryId CaptureEvent(SentryEvent evt, Hint hint, Scope scope = null) => SentryId.Empty;
+        public SentryId CaptureEvent(SentryEvent evt, SentryHint hint, Scope scope = null) => SentryId.Empty;
 
-        public void CaptureTransaction(Transaction transaction, Hint hint) { }
+        public void CaptureTransaction(SentryTransaction transaction, SentryHint hint) { }
 
         public BaggageHeader GetBaggage() => null;
 
@@ -78,18 +81,20 @@ namespace Sentry.Xamarin.Forms.Testing.Mock
 
         public TransactionContext ContinueTrace(SentryTraceHeader traceHeader, BaggageHeader baggageHeader, string name = null, string operation = null) => null;
 
-        public SentryId CaptureEvent(SentryEvent evt, Hint hint, Action<Scope> configureScope)
+        public SentryId CaptureEvent(SentryEvent evt, SentryHint hint, Action<Scope> configureScope)
         {
             CaptureEventCount++;
             return evt.EventId;
         }
 
-        public SentryId CaptureEvent(SentryEvent evt, Scope scope = null, Hint hint = null)
+        public SentryId CaptureEvent(SentryEvent evt, Scope scope = null, SentryHint hint = null)
         {
             CaptureEventCount++;
             return evt.EventId;
         }
 
-        public void CaptureTransaction(Transaction transaction, Scope scope, Hint hint) { }
+        public void CaptureTransaction(SentryTransaction transaction, Scope scope, SentryHint hint) { }
+
+        public bool CaptureEnvelope(Envelope envelope) => true;
     }
 }


### PR DESCRIPTION
- fixed break changes.
- bumped android API to 30 due to new Google requirements.
-  bump Sentry .NET to 4.0.3
- fixed github workflow build that broke with the API increase.