### PR TITLE
Bump Sentry .NET 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
 </plist>
 ```
 
+### Dependencies
+
+- Bump Sentry.NET 4.5.0 ([#154](https://github.com/getsentry/sentry-xamarin/pull/154))
+
 ## 2.0.0
 
 ### Sentry Self-hosted Compatibility

--- a/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+++ b/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
@@ -60,7 +60,7 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Sends sources to Sentry, enabling display of source context. -->
     <SentryUploadSources>true</SentryUploadSources>
-    <SentryCLIUploadOptions>--wait</SentryCLIUploadOptions>
+    <SentryCLIUploadOptions>--wait --allow_failure</SentryCLIUploadOptions>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+++ b/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
@@ -60,7 +60,8 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Sends sources to Sentry, enabling display of source context. -->
     <SentryUploadSources>true</SentryUploadSources>
-    <SentryCLIUploadOptions>--allow_failure </SentryCLIUploadOptions>
+    <SentryCLIUploadOptions>--wait</SentryCLIUploadOptions>
+    <UseSentryCLI>false</UseSentryCLI>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
+++ b/Samples/Sample.Xamarin.Droid/Sample.Xamarin.Droid.csproj
@@ -60,7 +60,7 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Sends sources to Sentry, enabling display of source context. -->
     <SentryUploadSources>true</SentryUploadSources>
-    <SentryCLIUploadOptions>--wait --allow_failure</SentryCLIUploadOptions>
+    <SentryCLIUploadOptions>--allow_failure </SentryCLIUploadOptions>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
+++ b/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
@@ -41,7 +41,8 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Sends sources to Sentry, enabling display of source context. -->
     <SentryUploadSources>true</SentryUploadSources>
-    <SentryCLIUploadOptions>--wait --allow_failure</SentryCLIUploadOptions>
+    <SentryCLIUploadOptions>--wait</SentryCLIUploadOptions>
+    <UseSentryCLI>false</UseSentryCLI>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
@@ -80,6 +81,8 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Sends sources to Sentry, enabling display of source context. -->
     <SentryUploadSources>true</SentryUploadSources>
+    <SentryCLIUploadOptions>--wait</SentryCLIUploadOptions>
+    <UseSentryCLI>false</UseSentryCLI>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>

--- a/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
+++ b/Samples/Sample.Xamarin.iOS/Sample.Xamarin.iOS.csproj
@@ -41,7 +41,7 @@
     <SentryUploadSymbols>true</SentryUploadSymbols>
     <!-- Sends sources to Sentry, enabling display of source context. -->
     <SentryUploadSources>true</SentryUploadSources>
-    <SentryCLIUploadOptions>--wait</SentryCLIUploadOptions>
+    <SentryCLIUploadOptions>--wait --allow_failure</SentryCLIUploadOptions>
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>

--- a/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
+++ b/Src/Sentry.Xamarin/Sentry.Xamarin.csproj
@@ -46,13 +46,13 @@
 		<None Include="Internals\**\*.mac*.cs" />
 		<None Include="Internals\**\*.droid*.cs" />
 		<None Include="Internals\**\*.uwp*.cs" />
-		<None Include="Privacy\SentryPrivacyInfo.xcprivacy" Pack="true" PackagePath="Privacy\SentryPrivacyInfo.xcprivacy"/>
+		<None Include="Privacy\SentryPrivacyInfo.xcprivacy" Pack="true" PackagePath="Privacy\SentryPrivacyInfo.xcprivacy" />
 		<None Include="buildTransitive\Sentry.Xamarin.targets" Pack="true" PackagePath="buildTransitive\Sentry.Xamarin.targets" />
 		<None Include="buildTransitive\Sentry.Xamarin.targets" Pack="true" PackagePath="build\Sentry.Xamarin.targets" />
 	</ItemGroup>	
 
 	<ItemGroup>
-		<PackageReference Include="Sentry" Version="4.0.3" />
+		<PackageReference Include="Sentry" Version="4.5.0" />
 		<PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
 	</ItemGroup>
 
@@ -70,7 +70,7 @@
 	
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('monoandroid')) ">
 		<Compile Include="Internals\**\*.droid*.cs" />
-		<PackageReference Include="Sentry.Android.AssemblyReader" Version="4.0.3" />
+		<PackageReference Include="Sentry.Android.AssemblyReader" Version="4.5.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.StartsWith('uap'))">

--- a/Tests/Sentry.Xamarin.Forms.Testing/Mock/MockHub.cs
+++ b/Tests/Sentry.Xamarin.Forms.Testing/Mock/MockHub.cs
@@ -96,5 +96,7 @@ namespace Sentry.Xamarin.Forms.Testing.Mock
         public void CaptureTransaction(SentryTransaction transaction, Scope scope, SentryHint hint) { }
 
         public bool CaptureEnvelope(Envelope envelope) => true;
+
+        public SentryId CaptureCheckIn(string monitorSlug, CheckInStatus status, SentryId? sentryId = null, TimeSpan? duration = null, Scope scope = null) => SentryId.Empty;
     }
 }


### PR DESCRIPTION
This PR bumps Sentry .NET to version 4.5.0.

No break changes were seen.